### PR TITLE
Add astro-i18next setup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,11 @@
 import { defineConfig } from "astro/config";
+import i18next from "astro-i18next";
 
 export default defineConfig({
-  // Configuración por defecto
+  integrations: [
+    i18next({
+      defaultLocale: "es",
+      supportedLocales: ["es", "en"],
+    }),
+  ],
 });

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,38 @@
+{
+  "title": "Wipodev - Mods Portfolio",
+  "hero": {
+    "avatarAlt": "Avatar Wipodev",
+    "tooltip": "Interested in a custom mod?",
+    "contact": "Contact me",
+    "subtitle": "Modding without limits"
+  },
+  "nextSectionButton": {
+    "label": "↓ See more"
+  },
+  "modsSection": {
+    "title": "Featured Projects",
+    "omedwellerDesc": "A loyal creature that evolves, bonds with you and reacts dynamically to the world. Perfect for soulful adventures.",
+    "playerCloneDesc": "Create clones of real players to simulate epic battles. Free-for-all, team mode or custom trials.",
+    "silentMaskDesc": "Hide in plain sight. This mask turns the player into an entity ignored by hostile mobs. Glitch aesthetics and pure stealth."
+  },
+  "appsSection": {
+    "title": "Other Programming Projects",
+    "voiceAssistantDesc": "Desktop assistant built with Python featuring voice recognition, custom commands and spoken responses.",
+    "controlPanelDesc": "Administrative interface built in PHP and JavaScript with authentication, user management and dynamic statistics.",
+    "debtManagerDesc": "Python app to manage personal loans with notifications and local database."
+  },
+  "modCard": {
+    "seeMore": "See more →"
+  },
+  "contact": {
+    "title": "Contact Me",
+    "prompt": "Have an idea for a mod or need help with custom programming? Send me a message and let's work together.",
+    "name": "Name",
+    "email": "Email",
+    "message": "Message",
+    "send": "Send"
+  },
+  "footer": {
+    "copyright": "© 2025 Wipodev. All rights reserved."
+  }
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,38 @@
+{
+  "title": "Wipodev - Mods Portfolio",
+  "hero": {
+    "avatarAlt": "Avatar Wipodev",
+    "tooltip": "¿Interesado en un mod personalizado?",
+    "contact": "Contáctame",
+    "subtitle": "Modding sin límites"
+  },
+  "nextSectionButton": {
+    "label": "↓ Ver más"
+  },
+  "modsSection": {
+    "title": "Proyectos Destacados",
+    "omedwellerDesc": "Una criatura leal que evoluciona, se vincula contigo y reacciona dinámicamente al mundo. Perfecto para aventuras con alma.",
+    "playerCloneDesc": "Crea clones de jugadores reales para simular combates épicos. Modo todos contra todos, por equipos o pruebas personalizadas.",
+    "silentMaskDesc": "Ocúltate a plena vista. Esta máscara convierte al jugador en un ente ignorado por mobs hostiles. Estética glitch y sigilo puro."
+  },
+  "appsSection": {
+    "title": "Otros Trabajos de Programación",
+    "voiceAssistantDesc": "Desarrollo de un asistente de escritorio en Python con reconocimiento de voz, comandos personalizados y respuestas habladas.",
+    "controlPanelDesc": "Interfaz administrativa desarrollada en PHP y JavaScript con autenticación, control de usuarios y estadísticas dinámicas.",
+    "debtManagerDesc": "Aplicación en Python para organizar y llevar control de préstamos personales, con notificaciones y base de datos local."
+  },
+  "modCard": {
+    "seeMore": "Ver más →"
+  },
+  "contact": {
+    "title": "Contáctame",
+    "prompt": "¿Tienes una idea para un mod o necesitas ayuda con programación personalizada? Escríbeme y trabajemos juntos.",
+    "name": "Nombre",
+    "email": "Correo electrónico",
+    "message": "Mensaje",
+    "send": "Enviar"
+  },
+  "footer": {
+    "copyright": "© 2025 Wipodev. Todos los derechos reservados."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "latest"
+    "astro": "latest",
+    "astro-i18next": "latest",
+    "i18next": "latest"
   }
 }

--- a/src/components/AppsSection.astro
+++ b/src/components/AppsSection.astro
@@ -1,33 +1,36 @@
 ---
 import ProjectsListSection from './ProjectsListSection.astro';
+import { useTranslation } from 'astro-i18next';
+
+const { t } = useTranslation();
 
 const appCards = [
 {
     title: "Asistente de Voz",
     img: "https://placehold.co/400x400/000000/00ffcc?text=Asistente+de+Voz",
     alt: "Asistente de Voz",
-    description: "Desarrollo de un asistente de escritorio en Python con reconocimiento de voz, comandos personalizados y respuestas habladas.",
+    description: t('appsSection.voiceAssistantDesc'),
     href: "#",
   },
   {
     title: "Panel de Control Web",
     img: "https://placehold.co/400x400/000000/00ffcc?text=Panel+de+Control",
     alt: "Panel de Control Web",
-    description: "Interfaz administrativa desarrollada en PHP y JavaScript con autenticación, control de usuarios y estadísticas dinámicas.",
+    description: t('appsSection.controlPanelDesc'),
     href: "#",
   },
   {
     title: "Gestor de Deudas",
     img: "https://placehold.co/400x400/000000/00ffcc?text=Gestor+Deudas",
     alt: "Gestor de Deudas",
-    description: "Aplicación en Python para organizar y llevar control de préstamos personales, con notificaciones y base de datos local.",
+    description: t('appsSection.debtManagerDesc'),
     href: "#",
   },
 ];
 ---
 <ProjectsListSection
   id="apps-cards"
-  title="Otros Trabajos de Programación"
+  title={t('appsSection.title')}
   backgroundColor="#111111"
   padding="4rem 2rem"
   cards={appCards}

--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -1,14 +1,17 @@
 ---
 ---
+import { useTranslation } from "astro-i18next";
+
+const { t } = useTranslation();
 <section id="contact" class="contact">
-  <h2>Contáctame</h2>
+  <h2>{t("contact.title")}</h2>
   <div class="contact-wrapper">
-    <p>¿Tienes una idea para un mod o necesitas ayuda con programación personalizada? Escríbeme y trabajemos juntos.</p>
+    <p>{t("contact.prompt")}</p>
     <form class="contact-form">
-      <input type="text" placeholder="Nombre" />
-      <input type="email" placeholder="Correo electrónico" />
-      <textarea rows="4" placeholder="Mensaje"></textarea>
-      <button type="submit" class="scroll-button section-button">Enviar</button>
+      <input type="text" placeholder={t("contact.name")} />
+      <input type="email" placeholder={t("contact.email")} />
+      <textarea rows="4" placeholder={t("contact.message")}></textarea>
+      <button type="submit" class="scroll-button section-button">{t("contact.send")}</button>
     </form>
     <div class="social-links">
       <a href="https://github.com/wipodev" target="_blank" title="GitHub">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,10 @@
 ---
 ---
+import { useTranslation } from "astro-i18next";
+
+const { t } = useTranslation();
 <footer>
-  <p>© 2025 Wipodev. Todos los derechos reservados.</p>
+  <p>{t("footer.copyright")}</p>
 </footer>
 <style>
 footer {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,17 +1,20 @@
 ---
 import NextSectionButton from "./NextSectionButton.astro"
+import { useTranslation } from "astro-i18next"
+
+const { t } = useTranslation();
 ---
 <header>
   <div class="header-bg"></div>
   <div class="avatar-wrapper">
-    <img class="avatar" src="https://avatars.githubusercontent.com/u/32320534" alt="Avatar Wipodev" />
+    <img class="avatar" src="https://avatars.githubusercontent.com/u/32320534" alt={t('hero.avatarAlt')} />
     <div class="avatar-tooltip">
-      ¿Interesado en un mod personalizado?<br>
-      <a href="#contacto">Contáctame →</a>
+      {t('hero.tooltip')}<br>
+      <a href="#contact">{t('hero.contact')} →</a>
     </div>
   </div>
   <h1>Wipodev</h1>
-  <p>Modding sin límites</p>
+  <p>{t('hero.subtitle')}</p>
   <NextSectionButton target="main" />
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/src/components/ModCard.astro
+++ b/src/components/ModCard.astro
@@ -7,13 +7,15 @@ export interface Props {
   href: string;
 }
 const { title, img, alt, description, href } = Astro.props;
+import { useTranslation } from 'astro-i18next';
+const { t } = useTranslation();
 ---
 <div class="mod-card">
   <h3>{title}</h3>
   <img src={img} alt={alt} />
   <div class="mod-info">
     <p>{description}</p>
-    <a href={href} target="_blank">Ver más →</a>
+    <a href={href} target="_blank">{t('modCard.seeMore')}</a>
   </div>
 </div>
 <style>

--- a/src/components/ModsSection.astro
+++ b/src/components/ModsSection.astro
@@ -1,33 +1,36 @@
 ---
 import ProjectsListSection from './ProjectsListSection.astro';
+import { useTranslation } from 'astro-i18next';
+
+const { t } = useTranslation();
 
 const modsCards = [
   {
     title: "Omedweller",
     img: "https://media.forgecdn.net/attachments/1148/570/logo-jpeg.jpeg",
     alt: "Mod Omedweller",
-    description: "Una criatura leal que evoluciona, se vincula contigo y reacciona dinámicamente al mundo. Perfecto para aventuras con alma.",
+    description: t('modsSection.omedwellerDesc'),
     href: "https://www.curseforge.com/minecraft/mc-mods/omedweller",
   },
   {
     title: "Player Clone",
     img: "https://media.forgecdn.net/attachments/1186/622/logo-png.png",
     alt: "Mod Player Clone",
-    description: "Crea clones de jugadores reales para simular combates épicos. Modo todos contra todos, por equipos o pruebas personalizadas.",
+    description: t('modsSection.playerCloneDesc'),
     href: "https://www.curseforge.com/minecraft/mc-mods/player-clone",
   },
   {
     title: "Silent Mask",
     img: "https://media.forgecdn.net/attachments/1204/80/logo-png.png",
     alt: "Mod Silent Mask",
-    description: "Ocúltate a plena vista. Esta máscara convierte al jugador en un ente ignorado por mobs hostiles. Estética glitch y sigilo puro.",
+    description: t('modsSection.silentMaskDesc'),
     href: "https://www.curseforge.com/minecraft/mc-mods/silent-mask",
   },
 ];
 ---
 <ProjectsListSection
   id="mods-cards"
-  title="Proyectos Destacados"
+  title={t('modsSection.title')}
   backgroundColor="#0a0a0a"
   padding="2rem"
   cards={modsCards}

--- a/src/components/NextSectionButton.astro
+++ b/src/components/NextSectionButton.astro
@@ -1,12 +1,16 @@
 ---
+import { useTranslation } from "astro-i18next";
+
 export interface Props {
   target: string;
   label?: string;
 }
-const { target, label = "\u2193 Ver m\u00E1s" } = Astro.props;
+const { target, label } = Astro.props;
+const { t } = useTranslation();
+const finalLabel = label ?? t('nextSectionButton.label');
 ---
 <div class="next-section">
-  <button class="scroll-button section-button" onclick={`document.querySelector('${target}').scrollIntoView({ behavior: 'smooth' });`}>{label}</button>
+  <button class="scroll-button section-button" onclick={`document.querySelector('${target}').scrollIntoView({ behavior: 'smooth' });`}>{finalLabel}</button>
 </div>
 <style>
 .next-section {

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,10 +1,10 @@
 ---
-import "../styles/global.css";
-import Hero from "../components/Hero.astro";
-import ModsSection from "../components/ModsSection.astro";
-import AppsSection from "../components/AppsSection.astro";
-import ContactSection from "../components/ContactSection.astro";
-import Footer from "../components/Footer.astro";
+import "../../styles/global.css";
+import Hero from "../../components/Hero.astro";
+import ModsSection from "../../components/ModsSection.astro";
+import AppsSection from "../../components/AppsSection.astro";
+import ContactSection from "../../components/ContactSection.astro";
+import Footer from "../../components/Footer.astro";
 import { useTranslation } from "astro-i18next";
 
 const { t, locale } = useTranslation();


### PR DESCRIPTION
## Summary
- add astro-i18next and i18next dependencies
- configure astro-i18next in `astro.config.mjs`
- implement translations in all components
- add Spanish and English locale files
- localize pages and create `[lang]` route

## Testing
- `npm run dev` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476b697c30833095c4e366fa0acb10