### PR TITLE
Update README with translation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,19 @@ npm run dev
 npm run build
 npm run preview
 ```
+
+## Traducciones
+
+Este proyecto utiliza [astro-i18next](https://github.com/yassinedoghri/astro-i18next) para gestionar los textos en distintos idiomas. Los archivos de traducción se encuentran en el directorio `locales` y cada idioma está representado por un archivo JSON (por ejemplo `es.json` o `en.json`).
+
+Para añadir un nuevo idioma:
+
+1. Crea un archivo `locales/<codigo>.json` con las cadenas traducidas.
+2. Añade el código del idioma al arreglo `supportedLocales` en `astro.config.mjs`.
+
+Dentro de los componentes se debe importar el hook de esta manera:
+
+```js
+import { useTranslation } from "astro-i18next";
+```
+


### PR DESCRIPTION
## Summary
- explain astro-i18next usage
- document how to add locales and where JSON files live
- show import style for useTranslation hook

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684772a1c8d88330973d528bdc2ffddb