### PR TITLE
Fix astro-i18next import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Para añadir un nuevo idioma:
 Dentro de los componentes se debe importar el hook de esta manera:
 
 ```js
-import { useTranslation } from "astro-i18next";
+import useTranslation from "astro-i18next";
 ```
 

--- a/src/components/AppsSection.astro
+++ b/src/components/AppsSection.astro
@@ -1,6 +1,6 @@
 ---
 import ProjectsListSection from './ProjectsListSection.astro';
-import { useTranslation } from 'astro-i18next';
+import useTranslation from 'astro-i18next';
 
 const { t } = useTranslation();
 

--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -1,5 +1,5 @@
 ---
-import { useTranslation } from "astro-i18next";
+import useTranslation from "astro-i18next";
 const { t } = useTranslation();
 ---
 <section id="contact" class="contact">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { useTranslation } from "astro-i18next";
+import useTranslation from "astro-i18next";
 const { t } = useTranslation();
 ---
 <footer>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,6 +1,6 @@
 ---
 import NextSectionButton from "./NextSectionButton.astro"
-import { useTranslation } from "astro-i18next"
+import useTranslation from "astro-i18next"
 
 const { t } = useTranslation();
 ---

--- a/src/components/ModCard.astro
+++ b/src/components/ModCard.astro
@@ -7,7 +7,7 @@ export interface Props {
   href: string;
 }
 const { title, img, alt, description, href } = Astro.props;
-import { useTranslation } from 'astro-i18next';
+import useTranslation from 'astro-i18next';
 const { t } = useTranslation();
 ---
 <div class="mod-card">

--- a/src/components/ModsSection.astro
+++ b/src/components/ModsSection.astro
@@ -1,6 +1,6 @@
 ---
 import ProjectsListSection from './ProjectsListSection.astro';
-import { useTranslation } from 'astro-i18next';
+import useTranslation from 'astro-i18next';
 
 const { t } = useTranslation();
 

--- a/src/components/NextSectionButton.astro
+++ b/src/components/NextSectionButton.astro
@@ -1,5 +1,5 @@
 ---
-import { useTranslation } from "astro-i18next";
+import useTranslation from "astro-i18next";
 
 export interface Props {
   target: string;

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -5,7 +5,7 @@ import ModsSection from "../../components/ModsSection.astro";
 import AppsSection from "../../components/AppsSection.astro";
 import ContactSection from "../../components/ContactSection.astro";
 import Footer from "../../components/Footer.astro";
-import { useTranslation } from "astro-i18next";
+import useTranslation from "astro-i18next";
 
 const { t, locale } = useTranslation();
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import ModsSection from "../components/ModsSection.astro";
 import AppsSection from "../components/AppsSection.astro";
 import ContactSection from "../components/ContactSection.astro";
 import Footer from "../components/Footer.astro";
-import { useTranslation } from "astro-i18next";
+import useTranslation from "astro-i18next";
 
 const { t, locale } = useTranslation();
 ---


### PR DESCRIPTION
## Summary
- correct `useTranslation` import across project
- update README instructions

## Testing
- `npm view astro-i18next version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684775254bd48330a45cddda4367bdad