### PR TITLE
Fix translation hook usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ Para añadir un nuevo idioma:
 1. Crea un archivo `locales/<codigo>.json` con las cadenas traducidas.
 2. Añade el código del idioma al arreglo `supportedLocales` en `astro.config.mjs`.
 
-Dentro de los componentes se debe importar el hook de esta manera:
+Dentro de los componentes se debe importar el hook de esta manera y llamarlo con `await` para obtener las funciones de traducción:
 
 ```js
 import useTranslation from "astro-i18next";
+
+const { t } = await useTranslation();
 ```
 

--- a/src/components/AppsSection.astro
+++ b/src/components/AppsSection.astro
@@ -2,7 +2,7 @@
 import ProjectsListSection from './ProjectsListSection.astro';
 import useTranslation from 'astro-i18next';
 
-const { t } = useTranslation();
+const { t } = await useTranslation();
 
 const appCards = [
 {

--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -1,6 +1,6 @@
 ---
 import useTranslation from "astro-i18next";
-const { t } = useTranslation();
+const { t } = await useTranslation();
 ---
 <section id="contact" class="contact">
   <h2>{t("contact.title")}</h2>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import useTranslation from "astro-i18next";
-const { t } = useTranslation();
+const { t } = await useTranslation();
 ---
 <footer>
   <p>{t("footer.copyright")}</p>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,7 +2,7 @@
 import NextSectionButton from "./NextSectionButton.astro"
 import useTranslation from "astro-i18next"
 
-const { t } = useTranslation();
+const { t } = await useTranslation();
 ---
 <header>
   <div class="header-bg"></div>

--- a/src/components/ModCard.astro
+++ b/src/components/ModCard.astro
@@ -8,7 +8,7 @@ export interface Props {
 }
 const { title, img, alt, description, href } = Astro.props;
 import useTranslation from 'astro-i18next';
-const { t } = useTranslation();
+const { t } = await useTranslation();
 ---
 <div class="mod-card">
   <h3>{title}</h3>

--- a/src/components/ModsSection.astro
+++ b/src/components/ModsSection.astro
@@ -2,7 +2,7 @@
 import ProjectsListSection from './ProjectsListSection.astro';
 import useTranslation from 'astro-i18next';
 
-const { t } = useTranslation();
+const { t } = await useTranslation();
 
 const modsCards = [
   {

--- a/src/components/NextSectionButton.astro
+++ b/src/components/NextSectionButton.astro
@@ -6,7 +6,7 @@ export interface Props {
   label?: string;
 }
 const { target, label } = Astro.props;
-const { t } = useTranslation();
+const { t } = await useTranslation();
 const finalLabel = label ?? t('nextSectionButton.label');
 ---
 <div class="next-section">

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -7,7 +7,7 @@ import ContactSection from "../../components/ContactSection.astro";
 import Footer from "../../components/Footer.astro";
 import useTranslation from "astro-i18next";
 
-const { t, locale } = useTranslation();
+const { t, locale } = await useTranslation();
 ---
 <!DOCTYPE html>
 <html lang="{locale}">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import ContactSection from "../components/ContactSection.astro";
 import Footer from "../components/Footer.astro";
 import useTranslation from "astro-i18next";
 
-const { t, locale } = useTranslation();
+const { t, locale } = await useTranslation();
 ---
 <!DOCTYPE html>
 <html lang="{locale}">


### PR DESCRIPTION
## Summary
- await useTranslation hook to get translation functions
- document awaiting the translation hook in README

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847768d0bf48330ae5624c703cdfae3